### PR TITLE
Adjust description to output as memo

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -108,7 +108,7 @@ class Transaction
             $this->renderIfNotNull( 'L', $this->category ),
             $this->renderSplits(),
             $this->renderIfNotNull( 'C', $this->status ),
-            $this->renderIfNotNull( 'P', $this->description ),
+            $this->renderIfNotNull( 'M', $this->description ),
             '^',
         ];
 


### PR DESCRIPTION
Currently it outputs description as the payee description, which is only used sometimes for banking/investing. A better way would be to pass it as M or memo since it's better suited to handle any description.